### PR TITLE
Continuously mark pull requests as failing when there is an ongoing incident

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'dotenv'
 gem 'octokit'
 gem 'dry-struct'
 gem 'dry-types'
+gem 'rufus-scheduler'
 
 group :development, :test do
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,10 +45,15 @@ GEM
       dry-equalizer (~> 0.2)
       dry-inflector (~> 0.1, >= 0.1.2)
       dry-logic (~> 0.4, >= 0.4.2)
+    et-orbi (1.1.7)
+      tzinfo
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.13.0)
       faraday (>= 0.7.4, < 1.0)
+    fugit (1.1.8)
+      et-orbi (~> 1.1, >= 1.1.7)
+      raabro (~> 1.1)
     gli (2.18.0)
     hashie (3.6.0)
     i18n (1.5.3)
@@ -64,6 +69,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
+    raabro (1.1.6)
     rb-readline (0.5.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -80,6 +86,8 @@ GEM
     rspec-support (3.8.0)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
+    rufus-scheduler (3.5.2)
+      fugit (~> 1.1, >= 1.1.5)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -114,6 +122,7 @@ DEPENDENCIES
   rb-readline
   rspec
   rspec_junit_formatter
+  rufus-scheduler
   slack-ruby-bot
 
 BUNDLED WITH

--- a/app.rb
+++ b/app.rb
@@ -1,10 +1,12 @@
 require 'slack-ruby-bot'
 require 'pry'
 require 'dotenv'
+require 'rufus-scheduler'
 
 require './core/hold_deployments'
 require './core/continue_deployments'
 require './core/record_message_for_incident'
+require './core/update_pull_request_statuses'
 require './clients/slack/slack_client_wrapper'
 require './clients/slack/slack_message'
 require './clients/github/github_client_wrapper'
@@ -57,5 +59,15 @@ module Hooks
   end
 end
 
+
+scheduler = Rufus::Scheduler.new
+
+scheduler.every '10s' do
+  UpdatePullRequestStatuses.new(
+    incidents_repository: INCIDENTS_REPOSITORY
+  ).execute
+end
+
 BalloonBot.instance.on(:message, Hooks::Message.new)
 BalloonBot.run
+

--- a/clients/github/github_client_wrapper.rb
+++ b/clients/github/github_client_wrapper.rb
@@ -24,6 +24,8 @@ class GithubClientWrapper
         branch: pr[:head][:ref]
       )
     end
+
+    log_rate_limit
   end
 
   def set_status_for_commit(commit_sha:, status:, more_info_url: nil)
@@ -35,5 +37,11 @@ class GithubClientWrapper
       description: status.description,
       target_url: more_info_url || ''
     )
+
+    log_rate_limit
+  end
+
+  private def log_rate_limit
+    puts "Github rate limit: #{github_client.rate_limit}"
   end
 end

--- a/clients/github/github_client_wrapper.rb
+++ b/clients/github/github_client_wrapper.rb
@@ -18,17 +18,19 @@ class GithubClientWrapper
   end
 
   def open_pull_requests
+    log_rate_limit
+
     github_client.pull_requests(ENV['GITHUB_REPO'], { state: :open }).map do |pr|
       PullRequest.new(
         head_sha: pr[:head][:sha],
         branch: pr[:head][:ref]
       )
     end
-
-    log_rate_limit
   end
 
   def set_status_for_commit(commit_sha:, status:, more_info_url: nil)
+    log_rate_limit
+
     github_client.create_status(
       ENV['GITHUB_REPO'],
       commit_sha,
@@ -37,8 +39,6 @@ class GithubClientWrapper
       description: status.description,
       target_url: more_info_url || ''
     )
-
-    log_rate_limit
   end
 
   private def log_rate_limit

--- a/core/continue_deployments.rb
+++ b/core/continue_deployments.rb
@@ -18,6 +18,8 @@ class ContinueDeployments
     incident = incidents_repository.find_last_unresolved
 
     github_client.open_pull_requests.each do |pull_request|
+      puts "Marking PR for branch #{pull_request.branch} as passing"
+
       github_client.set_status_for_commit(
         commit_sha: pull_request.head_sha,
         status: Github::Status.success

--- a/core/update_pull_request_statuses.rb
+++ b/core/update_pull_request_statuses.rb
@@ -1,0 +1,36 @@
+require './clients/github/github_client_wrapper'
+require './clients/github/status'
+require 'pry'
+
+class UpdatePullRequestStatuses
+  attr_reader :github_client, :incidents_repository
+
+  def initialize(
+    github_client: GithubClientWrapper.new,
+    incidents_repository:
+  )
+    @github_client = github_client
+    @incidents_repository = incidents_repository
+  end
+
+  def execute
+    if active_incident?
+      puts "Ongoing incident: marking all open pull requests as failing"
+      mark_open_pull_requests_as_failing
+    end
+  end
+
+  private def active_incident?
+    incidents_repository.find_last_unresolved != nil
+  end
+
+  private def mark_open_pull_requests_as_failing
+    github_client.open_pull_requests.each do |pull_request|
+      puts "Marking PR for branch #{pull_request.branch} as failing"
+      github_client.set_status_for_commit(
+        commit_sha: pull_request.head_sha,
+        status: Github::Status.failure
+      )
+    end
+  end
+end

--- a/spec/core/hold_deployments_spec.rb
+++ b/spec/core/hold_deployments_spec.rb
@@ -65,7 +65,7 @@ describe HoldDeployments do
             .twice
         end
 
-        it 'sets a github failing github status' do
+        it 'sets a failing github status' do
           expect(github_client_spy).to receive(:set_status_for_commit)
             .with(
               commit_sha: '123abc',

--- a/spec/core/update_pull_request_statuses_spec.rb
+++ b/spec/core/update_pull_request_statuses_spec.rb
@@ -1,0 +1,77 @@
+require 'rspec'
+require './clients/github/github_client_wrapper'
+require './clients/github/status'
+require './clients/slack/slack_message'
+require './clients/slack/slack_client_wrapper'
+require './core/update_pull_request_statuses'
+require './core/hold_deployments'
+
+describe "Integration Test: HoldDeployments + UpdatePullRequestStatuses" do
+  let(:github_client_spy) { spy(GithubClientWrapper) }
+  let(:incidents_repository) { IncidentsRepository.new }
+
+  let(:hold_deployments) {
+    HoldDeployments.new(
+      chat_client: spy(SlackClientWrapper),
+      github_client: spy(GithubClientWrapper),
+      incidents_repository: incidents_repository
+    )
+  }
+
+  subject do
+    UpdatePullRequestStatuses.new(
+      github_client: github_client_spy,
+      incidents_repository: incidents_repository
+    )
+  end
+
+  describe '#execute' do
+    context 'when deployments have been previously held' do
+      before do
+        fake_slack_message = SlackMessage.new(timestamp: 'some time', channel_id: 'some channel')
+        hold_deployments_request = HoldDeployments::Request.new(triggered_by: fake_slack_message)
+
+        hold_deployments.execute(hold_deployments_request)
+      end
+
+      context 'for each open PR on the configured github repo' do
+        before do
+          expect(github_client_spy).to receive(:open_pull_requests)
+            .and_return(
+             [
+               PullRequest.new(head_sha: '123abc', branch: 'some-branch'),
+               PullRequest.new(head_sha: '456def', branch: 'some-branch')
+             ]
+            )
+
+        end
+
+        it 'sets a failing github status' do
+          expect(github_client_spy).to receive(:set_status_for_commit)
+            .with(
+             commit_sha: '123abc',
+             status: instance_of(Github::FailureStatus)
+            )
+          expect(github_client_spy).to receive(:set_status_for_commit)
+             .with(
+               commit_sha: '456def',
+               status: instance_of(Github::FailureStatus)
+             )
+
+          subject.execute
+        end
+      end
+    end
+
+    context 'when deployments have not been previously held' do
+      context 'it does not set failing statuses on open PRs in github' do
+        it 'sets a failing github status' do
+          expect(github_client_spy).not_to receive(:open_pull_requests)
+          expect(github_client_spy).not_to receive(:set_status_for_commit)
+
+          subject.execute
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Why 

We need to make sure that users who make new PRs while there is an incident occuring on master are also notified of the failure (i.e. we can just call the github API once when someone tells balloon bot to hold deploys, we have to call it repeatedly)

NOTES:
* Creates an integration-style test for testing how HoldDeployments and UpdatePullRequestStatuses interact
* UpdatePullRequestStatuses is called on a cron schedule of every 10 seconds. Here are some notes about the number of requests this could produce:

(1 get request for all open pull requests (lets say 30) + 30 set statuses (one per request) / 1 min

if an incident lasts for 1 hour that would be: 

31 requests per minute * 60 = 1860 requests per hour. This would keep us well under 5000 requests per hour, the max for github. May be able to bump the cron to 5 seconds depending on the average # of open PRs at any given time in our repo.

https://developer.github.com/apps/building-github-apps/understanding-rate-limits-for-github-apps/

FUTURE PR:
Make the poll schedule configurable through .env

